### PR TITLE
feat: 장바구니 페이지 구현

### DIFF
--- a/public/data/Cart/cart_list.json
+++ b/public/data/Cart/cart_list.json
@@ -1,0 +1,68 @@
+[
+  { 
+    "id": 0,
+    "region": "청주",
+    "title": "신품종 킹머스켓 & 샤인머스켓 | 최초공개 추석 한정판",
+    "image" : "https://cdn.pixabay.com/photo/2015/12/09/17/11/vegetables-1085063_1280.jpg",
+    "products": [
+      {
+        "id": 123,  
+        "name": "선택1",
+        "subname":"멋쟁이 토마토",
+        "type": "토마토",
+        "weight": 10,
+        "price": 10000,
+        "quantity" : 3,
+        "image" : "https://cdn.pixabay.com/photo/2015/12/09/17/11/vegetables-1085063_1280.jpg"
+      },
+      {
+        "id": 1234,  
+        "name": "선택2",
+        "subname":"멋쟁이 자두",
+        "type": "자두",
+        "weight": 5,
+        "price": 8000,
+        "quantity" : 2,
+        "image" : "https://cdn.pixabay.com/photo/2015/12/09/17/11/vegetables-1085063_1280.jpg"
+      },
+      {
+        "id": 12345,  
+        "name": "선택3",
+        "subname":"멋쟁이 샤머",
+        "type": "샤인머스켓",
+        "weight": 5,
+        "price": 15000,
+        "quantity" : 1,
+        "image" : "https://cdn.pixabay.com/photo/2015/12/09/17/11/vegetables-1085063_1280.jpg"
+      }
+    ]
+  },
+  { 
+    "id": 11,
+    "region": "횡성",
+    "title": "신품종 사과 | 최초공개 추석 한정판",
+    "image" : "https://cdn.pixabay.com/photo/2015/12/09/17/11/vegetables-1085063_1280.jpg",
+    "products": [
+      {
+        "id": 45,  
+        "name": "선택1",
+        "subname":"멋쟁이 토마토",
+        "type": "토마토",
+        "weight": 20,
+        "price": 10000,
+        "quantity" : 3,
+        "image" : "https://cdn.pixabay.com/photo/2015/12/09/17/11/vegetables-1085063_1280.jpg"
+      },
+      {
+        "id": 456,  
+        "name": "선택3",
+        "subname":"멋쟁이 사과",
+        "type": "사과",
+        "weight": 15,
+        "price": 15000,
+        "quantity" : 5,
+        "image" : "https://cdn.pixabay.com/photo/2015/12/09/17/11/vegetables-1085063_1280.jpg"
+      }
+    ]
+  }
+]

--- a/src/apis/Cart/index.js
+++ b/src/apis/Cart/index.js
@@ -1,0 +1,8 @@
+import axios from "axios";
+import { axiosInstance } from "..";
+
+export const getAllCartList = async () => {
+  // const { data } = await axiosInstance.get(`/api/v1/carts`);
+  const {data} = await axios.get('/data/Cart/cart_list.json')
+  return data;
+}

--- a/src/components/Cart/CartList.jsx
+++ b/src/components/Cart/CartList.jsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import styled from 'styled-components'
+import OneCartItem from './OneCartItem'
+import { IoIosArrowForward } from "react-icons/io";
+
+export default function CardList({item: {region, title, image, products}, onChange, checkedList}) {
+  return (
+    <>
+      <Container>
+        <FundingTitle>
+          <ImageWrapper>
+            <img src={image} />
+          </ImageWrapper>
+          <FundingInfo>
+            <TownCategory>
+              <p>마을의 펀딩</p>
+              <IoIosArrowForward />
+              <TownItem>{region}</TownItem>
+            </TownCategory>
+            <Title>
+              <p>{title}</p>
+            </Title>
+          </FundingInfo>
+        </FundingTitle>
+        {products && products.map((product) => (
+          <OneCartItem key={product.id} product={product} onChange={onChange} checkedList={checkedList}/>
+        ))}
+      </Container>
+    </>
+  )
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  height: fit-content;
+  background-color: #FFF5E9; 
+  margin-top: 1.5rem;
+`
+const FundingTitle = styled.div`
+  width: 100%;
+  max-width: 70rem;
+  display: flex;
+  gap: 2.19rem;
+  align-items: center;
+  margin: 4rem 0;
+`
+
+const ImageWrapper = styled.div`
+  width: 10rem;
+  height: 7.5rem;
+
+  img {
+    width: 100%;
+    height: 100%;
+  }
+`
+
+const FundingInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.06rem;
+`
+
+const TownCategory = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  p, svg {
+    color: #A2A2A2;
+  }
+`
+
+const TownItem = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: white;
+  width: 4rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+  border-radius: 0.78125rem;
+  background: #FF9C2F;
+`
+
+const Title = styled.div`
+  p{
+    color: #2A2A2A;
+    font-size: 1.75rem;
+    font-weight: 700;
+  }
+`

--- a/src/components/Cart/OneCartItem.jsx
+++ b/src/components/Cart/OneCartItem.jsx
@@ -1,0 +1,239 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import { FaMinus, FaPlus } from "react-icons/fa6";
+
+
+export default function OneCartItem({product, product: {id, name, subname, type, weight, price, quantity, image}, onChange, checkedList}) {
+  const [quantityNum, setQuantityNum] = useState(quantity)  
+  const [checked, setChecked] = useState(false)
+
+  const handleQuantity = (num) => {
+    setQuantityNum((prev) => prev+num < 1 ? 1 : prev+num)
+  }
+
+  const handleCheckbox = ({target}) => {
+    setChecked(!checked)
+    onChange(target.checked, id, quantityNum)
+  }
+
+  return (
+    <CardWrapper>
+      <input 
+        type="checkbox" 
+        id="buy" 
+        name="buy" 
+        color={`var(--main-color)`}
+        onChange={(e) => handleCheckbox(e)}
+        checked = {checked}
+      />  
+      <ImageWrapper>
+        <img src={image} />
+      </ImageWrapper>
+      <Description>
+        <Title>
+          <h2>{name}</h2>
+          <p># {subname}</p>
+        </Title>
+        <Detail>
+          <div>
+            <p>품 명</p>
+            <p>{type}</p>
+          </div>
+          <div>
+            <p>무 게</p>
+            <p>{weight}kg</p>
+          </div>
+          <div>
+            <p>가 격</p>
+            <p>{price.toLocaleString()}원</p>
+          </div>
+        </Detail>
+      </Description>
+      <DashedLine/>
+      <QuantityAndPrice>
+        <QuantityBox>
+          <div>
+            <p>수량</p>
+          </div>
+          <QuantityControl>
+            <FaMinus onClick={() =>handleQuantity(-1)} />
+            <p>{quantityNum}</p>
+            <FaPlus onClick={() =>handleQuantity(1)} />
+          </QuantityControl>
+        </QuantityBox>
+        <DashedLine />
+        <Price>
+            <p>상품금액</p>
+            <p>{(quantityNum*price).toLocaleString()}원</p>
+          </Price>
+      </QuantityAndPrice>
+
+    </CardWrapper>
+  )
+}
+
+
+const CardWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  background-color: white;
+  width: 100%;
+  max-width: 70rem;
+  height: 17rem;
+  max-height: 18rem;
+  border-radius: 1.25rem;
+  box-shadow: 0px 1px 15px 0px rgba(0, 0, 0, 0.20);
+  margin-bottom: 1.8rem;
+
+  input {
+    width: 1.5rem;
+    height: 1.5rem;
+    flex-shrink: 0;
+    border-radius: 5px;
+    accent-color: #FF4256;
+    margin: 0 1.5rem;
+  }
+`
+
+const ImageWrapper = styled.div`
+  width: 18rem;
+  height: 13rem;
+  flex-shrink: 0;
+
+  img {
+    width: 100%;
+    height: 100%;
+    border-radius: 0.625rem;
+  }
+`
+
+const Description = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.87rem;
+  margin: 0 2.5rem;
+  flex-shrink: 0;
+`
+
+const Title = styled.div`
+  display: flex;
+  gap: 1rem;
+  font-weight: 600;
+  align-items: center;
+
+  h2{
+    font-size: 1.75rem;
+  }
+
+  p{
+    font-size: 1.25rem;
+    color: #FF9C2F;
+  }
+`
+
+const Detail = styled.div`
+  font-size: 1.25rem;
+
+  div{
+    display: flex;
+    gap: 1.5rem;
+    margin-bottom: 0.62rem;
+
+    p:first-child {
+      font-weight: 600;
+    }
+  }
+`
+
+const QuantityAndPrice = styled.div`
+  display: flex;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  @media screen and (max-width: 1023px) {
+    flex-direction: column;
+    gap: 1rem;
+  }
+`
+
+const QuantityBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  margin: 0 2.5rem;
+
+  div{
+    display: flex;
+    gap: 1rem;
+    font-size: 1.25rem;
+
+    p:first-child {
+      font-weight: 600;
+    }
+  } 
+  @media screen and (max-width: 1023px) {
+    p:first-child{
+      display: none;
+    }
+  }
+`
+
+const QuantityControl = styled.div`
+  display: flex;
+  min-width: 7.125rem;
+  height: 2.1875rem;
+  padding: 0.5rem;
+  color: var(--main-color);
+  border: 1px solid var(--main-color);
+  border-radius: 5.25rem;
+  justify-content: center;
+  align-items: center;
+  font-weight: 500;
+  
+  svg {
+    cursor: pointer;
+    stroke-width: 2px;
+  }
+  
+  p{
+    color: #2C2C2C;
+    font-weight: 500;
+    font-size: 1.25rem;
+  }
+
+`
+
+
+const Price = styled.div`
+  display: flex;
+  flex-direction: column;
+  color: #2A2A2A;
+  letter-spacing: 0.03rem;
+  text-align: center;
+  margin: 0 4rem;
+  p:first-child {
+    font-size: 1.5rem;
+    font-weight: 500;
+    margin-bottom: 0.56rem;
+  }
+  p:last-child {
+    font-size: 1.75rem;
+    font-weight: 700;
+  }
+
+  @media screen and (max-width: 1023px) {
+    p:first-child{
+      display: none;
+    }
+  }
+`
+
+const DashedLine = styled.div`
+  width: 5px;
+  height: 100%;
+  border-right: 2px dashed #EDEDED; 
+  @media screen and (max-width: 1023px) {
+    display: none;
+  }
+`

--- a/src/components/ProfileBanner/index.jsx
+++ b/src/components/ProfileBanner/index.jsx
@@ -1,13 +1,14 @@
 //프로필 상단 배너
 import React, { useEffect, useState } from 'react';
 
-import styled from 'styled-components';
-import { LuChevronRight } from 'react-icons/lu';
-import ProfileImage from '../../assets/imgs/mypage_profile.png';
-import CarrotImg from '../../assets/imgs/Carrot.png';
-import PlantImg from '../../assets/imgs/growing_plant.png';
-import SettingImg from '../../assets/imgs/setting_icon.png';
-import { useNavigate } from 'react-router-dom';
+import styled from "styled-components";
+import { LuChevronRight } from "react-icons/lu";
+import ProfileImage from "../../assets/imgs/mypage_profile.png";
+import CarrotImg from "../../assets/imgs/Carrot.png";
+import PlantImg from "../../assets/imgs/growing_plant.png";
+import SettingImg from "../../assets/imgs/setting_icon.png";
+import { useNavigate } from "react-router-dom";
+import axios from 'axios';
 
 export default function ProfileBanner() {
   const navigate = useNavigate();

--- a/src/hooks/useCart.jsx
+++ b/src/hooks/useCart.jsx
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAllCartList } from '../apis/Cart';
+
+export default function useCart() {
+  const getCarts = useQuery({
+    queryKey: ['carts'],
+    queryFn: getAllCartList,
+  });
+
+  return {getCarts}
+}
+

--- a/src/pages/Buying/Buying.jsx
+++ b/src/pages/Buying/Buying.jsx
@@ -103,7 +103,7 @@ export default function Buying() {
         <HeadLine></HeadLine>
         <ProductTitle>상품 종류</ProductTitle>
         <ProductContainer>
-          <Items/> 
+          <Items isDetailPage/> 
           {/* 상품 컴포넌트 */}
         </ProductContainer>
         <HeadLine></HeadLine>

--- a/src/pages/Buying/Items.jsx
+++ b/src/pages/Buying/Items.jsx
@@ -4,7 +4,8 @@ import axios from 'axios';
 import Tomato from '../../assets/imgs/Funding/Tomato.png';
 import Plum from '../../assets/imgs/Funding/Plum.png';
 import Peach from '../../assets/imgs/Funding/Peach.png';
-export default function Items() {
+
+export default function Items({isDetailPage}) {
     const [products, setProducts] = useState([]);
     const [selectedProducts, setSelectedProducts] = useState([]);
     const [notification, setNotification] = useState('');
@@ -147,18 +148,31 @@ const handleQuantityChange = (product, change) => {
                     <ProductPrice>
                       가 격<b>{product.price}원</b>
                     </ProductPrice>
-                    <QuantityControl>
-                <QuantityButton onClick={() => handleQuantityChange(product, -1)}>
-                  -
-                </QuantityButton>
-                <ProductQuantity>{product.quantity}</ProductQuantity>
-                <QuantityButton onClick={() => handleQuantityChange(product, 1)}>
-                  +
-                </QuantityButton>
-              </QuantityControl>
-              <SelectButton onClick={() => handleSelectClick(product)}>
-                담기
-              </SelectButton>
+                    {isDetailPage &&
+                      <>
+                      <QuantityControl>
+                        <QuantityButton
+                          onClick={() =>
+                            handleQuantityChange(product, setProducts)(-1)
+                          }
+                        >
+                          -
+                        </QuantityButton>
+                        <ProductQuantity>{product.quantity}</ProductQuantity>
+                        <QuantityButton
+                          onClick={() =>
+                            handleQuantityChange(product, setProducts)(1)
+                          }
+                        >
+                          +
+                        </QuantityButton>
+                      </QuantityControl>
+                      <SelectButton onClick={() => handleSelectClick(product)}>
+                        담기
+                      </SelectButton>
+                      </>
+                    }
+
                   </OptionContainer>
                 </Product>
               ))}
@@ -180,6 +194,7 @@ const Product = styled.div`
   background: #fff;
   border-radius: 10px;
   filter: drop-shadow(0px 1px 15px rgba(0, 0, 0, 0.2));
+  
   img {
     width: 100%;
     height: 50%;
@@ -190,6 +205,7 @@ const Product = styled.div`
 const ProductList = styled.div`
   display: flex;
   flex-wrap: nowrap; // 줄 바꿈 방지
+  overflow: auto;
 `;
 
 const OptionContainer = styled.div`

--- a/src/pages/Cart/index.jsx
+++ b/src/pages/Cart/index.jsx
@@ -1,0 +1,268 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import styled from 'styled-components'
+import CardList from '../../components/Cart/CartList'
+import { IoCloseOutline } from "react-icons/io5";
+import useCart from '../../hooks/useCart';
+import Items from '../Buying/Items';
+import { useNavigate } from 'react-router-dom';
+
+
+
+export default function Cart() {
+  const navigate = useNavigate()
+  const {getCarts: {data: cartList}} = useCart()
+  const [checkedList, setCheckedList] = useState(new Set())
+
+  // const handleOnCheckedAll = useCallback((checked) => { 
+  //   if(checked) {
+  //     const checkListArr = []
+  //     cartList.forEach((list) => list.forEach((product) => checkListArr.push(product.id)))
+  //     setCheckedList(checkListArr)
+  //   }else{
+  //     setCheckedList([])
+  //   }
+  // },[cartList])
+
+  const handleOnCheckedEach = useCallback((isChecked, id, quantity) => {
+    if(!isChecked) {
+      checkedList.add(id)
+      setCheckedList(checkedList)
+    }else if(isChecked && checkedList.has(id)){
+      checkedList.delete(id)
+      setCheckedList(checkedList)
+    }
+  },[cartList])
+
+
+  const getTotalPrice = () => {
+    let total = 0
+    cartList && cartList.map((list) => {
+      (list.products).map(({quantity, price}) => {
+        console.log("quantity, price", quantity, price)
+        total+=quantity*price
+      })
+    })
+    return total
+  }
+
+  let totalPrice = useMemo(() => getTotalPrice(), [cartList])
+
+  return (
+    <>
+      <Wrapper>
+        <Header>
+          <p>담은 목록</p>
+        </Header>
+        <CheckAndDelete>
+          <CheckAll>
+            <input 
+              type="checkbox" 
+              id="buy" 
+              name="buy" 
+              color={`var(--main-color)`}
+              // onChange={(e) => handleOnCheckedAll(e.target.checked)}
+              // checked = {
+              //   checkedList.length === 0 ? false : checkedList.length === cartList.length ? true : false
+              // }
+            />  
+            <p>전체 선택</p>
+          </CheckAll>
+          <DeleteChecked>
+            <IoCloseOutline />
+            <p>선택 삭제</p>
+          </DeleteChecked>
+        </CheckAndDelete>
+        {
+          cartList && cartList.map((item) => (
+            <CardList key={item.region} item={item} onChange = {handleOnCheckedEach} checkedList={checkedList}/>
+          ))
+        }
+        {/* <RecommendListWrapper>
+          <p>이런 상품은 어때요?</p>
+          <Items />
+        </RecommendListWrapper> */}
+      </Wrapper>
+      <FinalContainer>
+        <FinalWrapper>
+          <PriceBox>
+            <div>
+              <p>최종 구매 금액</p>
+              <p>{totalPrice.toLocaleString()}</p>
+            </div>
+            <SolidLine/>
+            <div>
+              <p>배송비</p>
+              <p>무료</p>
+            </div>
+          </PriceBox>
+          <GoToPayButton onClick={() => {navigate('/payment', {state: totalPrice})}}>구매하기</GoToPayButton>
+        </FinalWrapper>
+
+      </FinalContainer>
+    </>
+  )
+}
+
+const Wrapper = styled.div`
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  display : flex;
+  flex-direction: column;
+  position : relative;
+
+`
+
+const Header = styled.div`
+  
+  display : flex;
+  flex-direction: column;
+  text-align : center;
+  align-items: center;
+  height : 120px;
+  width : 780px;
+  position : relative;
+  margin-top : 0px;
+  
+  p{
+    
+    margin-top:40px;
+    top:70%;
+    color: #000;
+    text-align: center;
+    font-family: Pretendard;
+    font-size: 25px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: normal;
+    letter-spacing: 0.5px;
+  }
+`
+const CheckAndDelete = styled.div`
+  width: 100%;
+  max-width: 70rem;
+  display: flex;
+  justify-content: space-between;
+
+`
+
+const CheckAll = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 1.25rem;
+  font-weight: 500;
+
+  input {
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 5px;
+    accent-color: #FF4256;
+  }
+`
+
+const DeleteChecked = styled.button`
+  display: flex;
+  min-width: 7.125rem;
+  height: 2.1875rem;
+  padding: 0.5rem;
+  color: var(--main-color);
+  border: 1px solid var(--main-color);
+  border-radius: 5.25rem;
+  justify-content: center;
+  align-items: center;
+  font-weight: 500;
+
+  svg {
+    width: 1.375rem;
+    height: 1.375rem;
+    flex-shrink: 0;
+  }
+`
+
+const RecommendListWrapper = styled.div`
+  width: 100%;
+  max-width: 70rem;
+
+  p {
+    font-size: 1.75rem;
+    font-weight: 700;
+    text-align: left;
+    margin: 5.62rem 0 2.44rem 0;
+  }
+`
+
+const FinalContainer = styled.div`
+  width: 100%;
+  height: 11rem;
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: white;
+  box-shadow: 0px -2px 10px 1px #dfdfdf;
+`
+
+const FinalWrapper = styled.div`
+  width: 100%;
+  max-width: 70rem;
+  height: 3.5rem;
+  display: flex;
+  justify-content: space-between;
+
+  @media screen and (max-width: 1023px) {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: center;
+  }
+`
+
+const PriceBox = styled.div`
+  min-width: 33rem;
+  height: 100%;
+  align-items: center;
+  display: flex;
+  flex-shrink: 0;
+
+  gap: 3rem;
+  border-radius: 0.9375rem;
+  border: 1px solid #DFDFDF;
+  padding: 1.25rem 3.37rem;
+
+  div:first-child{
+    flex-grow: 3;
+  }
+  div:lst-child{
+    flex-grow: 1;
+  }
+  div{
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    p{
+      font-size: 1.2rem;
+    }
+    p:last-child {
+      font-weight: 700;
+    }
+  }
+`
+
+const GoToPayButton = styled.button`
+  width: 29rem;
+  height: 100%;
+  background-color: var(--main-color);
+  color: white;
+  font-size: 1.375rem;
+  font-weight: 800;
+  border-radius: 0.9375rem;
+
+`
+
+const SolidLine = styled.div`
+  width: 5px;
+  height: 1.5rem;;
+  border-right: 2px solid #EDEDED; 
+`


### PR DESCRIPTION
- 장바구니 페이지 ui 
- CartList(마을 별 상품 리스트), OneCartItem(담긴 상품 카드) 컴포넌트 구현
- Items 컴포넌트 isDetailPage props 추가하여 각 페이지에 적용
- '구매하기' 버튼 클릭 시 '/payment' 로 navigate (state에 totalPrice 전달)

<추가할 사항>
- 전체 선택(checkbox)
- checkList에 포함되는 상품만 getTotalPrice 함수로 계산하여 return